### PR TITLE
allow input of readonly arrays

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
-    "build"
+    "build",
+    "!build/tests/**"
   ],
   "repository": "github:krmax44/always-array",
   "author": "krmax44<hi@krmax44.de>",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test": "mocha -r ts-node/register 'src/**/*.test.ts' && yarn lint",
     "lint": "xo",
     "build": "tsc -p ./tsconfig.json && uglifyjs build/index.js -o build/index.js -m -c",
+    "prepare": "npm run build",
     "dev": "tsc -p ./tsconfig.json -w"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export default function alwaysArray<T>(input: T | T[]): T[] {
+export default function alwaysArray<T>(input: T | readonly T[]): readonly T[] {
 	return Array.isArray(input) ? input : [input];
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 export type SingleOrArray<T> = T | readonly T[];
 
-export default function alwaysArray<T>(input: SingleOrArray<T>): readonly T[] {
-	return Array.isArray(input) ? input : [input];
+export default function alwaysArray<T>(input: SingleOrArray<T>): T[] {
+	return Array.isArray(input) ? [...input] : [input];
 }
 
 if (typeof module !== 'undefined') {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,6 @@
-export default function alwaysArray<T>(input: T | readonly T[]): readonly T[] {
+export type SingleOrArray<T> = T | readonly T[];
+
+export default function alwaysArray<T>(input: SingleOrArray<T>): readonly T[] {
 	return Array.isArray(input) ? input : [input];
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,9 +2,9 @@
   "compilerOptions": {
     "module": "commonjs",
     "moduleResolution": "node",
-    "noImplicitAny": true,
     "preserveConstEnums": true,
     "target": "es2015",
+    "strict": true,
     "esModuleInterop": true,
     "declaration": true,
     "outDir": "./build/"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,11 +9,6 @@
     "declaration": true,
     "outDir": "./build/"
   },
-  "exclude": [
-    "node_modules",
-    "**/tests/**",
-    "**/build/**"
-  ],
   "include": [
     "src/**/*"
   ],


### PR DESCRIPTION
In my opinion this method (alwaysArray) is meant for function arguments to be more versatile.
But the internal code of the user wants to always have an array.

Using a readonly array as input allows for even more possible inputs. (writeable arrays can also be used in readonly arrays but not the other way around)
This has the drawback of only a readonly output array.
Internally the array from input shouldn't be changed anyway so this shouldn't be a problem.

BREAKING CHANGE: returns only a readonly array
This will result in a version 2.0.0 but this should not impact any good code as the input of a method shouldn't be changed anyway.