### PR TITLE
feat: allow iterable conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,4 +28,5 @@ alwaysArray(['foo']); // ['foo']
 const set = new Set([1, 2, 3]);
 alwaysArray(set); // [ Set { 1, 2, 3 } ]
 alwaysArray(set, { convertIterables: true }); // [1, 2, 3]
+alwaysArray('foo', { convertIterables: true }); // ['foo'] - albeit being an iterable, strings won't be spread into an array
 ```

--- a/README.md
+++ b/README.md
@@ -24,4 +24,8 @@ import alwaysArray from 'always-array';
 
 alwaysArray('foo'); // ['foo']
 alwaysArray(['foo']); // ['foo']
+
+const set = new Set([1, 2, 3]);
+alwaysArray(set); // [ Set { 1, 2, 3 } ]
+alwaysArray(set, { convertIterables: true }); // [1, 2, 3]
 ```

--- a/README.md
+++ b/README.md
@@ -27,6 +27,6 @@ alwaysArray(['foo']); // ['foo']
 
 const set = new Set([1, 2, 3]);
 alwaysArray(set); // [ Set { 1, 2, 3 } ]
-alwaysArray(set, { convertIterables: true }); // [1, 2, 3]
-alwaysArray('foo', { convertIterables: true }); // ['foo'] - albeit being an iterable, strings won't be spread into an array
+alwaysArray.convertIterables(set); // [1, 2, 3]
+alwaysArray.convertIterables('foo'); // ['foo'] - albeit being an iterable, strings won't be spread into an array
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,16 +22,20 @@ function alwaysArray<T>(input: SingleOrArray<T>, options?: Options): T[] {
 		...options
 	};
 
-	const isArray = Array.isArray(input);
+	if (Array.isArray(input)) {
+		return [...input];
+	}
 
-	const isIterable =
-		isArray ||
-		(options.convertIterables === true &&
-			input !== null &&
-			typeof input !== 'string' &&
-			typeof (input as Iterable<T>)[Symbol.iterator] === 'function');
+	if (
+		options.convertIterables === true &&
+		typeof input !== 'string' &&
+		input instanceof Object &&
+		typeof input[Symbol.iterator] === 'function'
+	) {
+		return [...input];
+	}
 
-	return isIterable ? [...(input as Iterable<T>)] : [input as T];
+	return [input as T];
 }
 
 export default alwaysArray;
@@ -40,4 +44,3 @@ if (typeof module !== 'undefined') {
 	module.exports = alwaysArray;
 	module.exports.default = alwaysArray;
 }
-

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,10 @@ interface Options {
  * @param input Input that will be converted to an array if it isn't already.
  * @param options.convertIterables [false] Iterables will be spread into an array.
  */
-export default function alwaysArray<T>(input: T | T[], options?: Options): T[] {
+export default function alwaysArray<T>(
+	input: T | T[] | Iterable<T>,
+	options?: Options
+): T[] {
 	options = {
 		convertIterables: false,
 		...options
@@ -17,12 +20,12 @@ export default function alwaysArray<T>(input: T | T[], options?: Options): T[] {
 		options.convertIterables === true &&
 		input !== null &&
 		typeof input !== 'string' &&
-		typeof (input as Iterable<any>)[Symbol.iterator] === 'function'
+		typeof (input as Iterable<T>)[Symbol.iterator] === 'function'
 	) {
-		return [...(input as Iterable<any>)];
+		return [...(input as Iterable<T>)];
 	}
 
-	return Array.isArray(input) ? input : [input];
+	return Array.isArray(input) ? input : [input as T];
 }
 
 if (typeof module !== 'undefined') {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,34 +1,19 @@
-type SingleOrArray<T> = T | Iterable<T> | readonly T[];
-
-interface Options {
-	convertIterables: boolean;
-}
-
 /**
  * Makes sure you're dealing with an array.
  * @param input Input that will be converted to an array if it isn't already.
- * @param options.convertIterables [false] Iterables will be spread into an array.
  */
-function alwaysArray<T>(
-	input: T | T[],
-	options?: { convertIterables: false | undefined }
-): T[];
-function alwaysArray<T>(
-	input: Iterable<T>,
-	options: { convertIterables: true }
-): T[];
-function alwaysArray<T>(input: SingleOrArray<T>, options?: Options): T[] {
-	options = {
-		convertIterables: false,
-		...options
-	};
+export default function alwaysArray<T>(input: T | readonly T[]): T[] {
+	return Array.isArray(input) ? [...input] : [input];
+}
 
-	if (Array.isArray(input)) {
-		return [...input];
-	}
-
+/**
+ * Makes sure you're dealing with an array. Iterables will be spread into an array.
+ * @param input Input that will be converted to an array if it isn't already.
+ */
+export function convertIterables<T>(
+	input: T | readonly T[] | Iterable<T>
+): T[] {
 	if (
-		options.convertIterables === true &&
 		typeof input !== 'string' &&
 		input instanceof Object &&
 		typeof input[Symbol.iterator] === 'function'
@@ -39,9 +24,8 @@ function alwaysArray<T>(input: SingleOrArray<T>, options?: Options): T[] {
 	return [input as T];
 }
 
-export default alwaysArray;
-
 if (typeof module !== 'undefined') {
 	module.exports = alwaysArray;
 	module.exports.default = alwaysArray;
+	module.exports.convertIterables = convertIterables;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,12 +9,13 @@ interface Options {
  * @param input Input that will be converted to an array if it isn't already.
  * @param options.convertIterables [false] Iterables will be spread into an array.
  */
-function alwaysArray(input: string, options?: Options): [string];
-function alwaysArray<T>(input: T[], options?: Options): T[];
-function alwaysArray<T>(input: T, options?: { convertIterables: false }): [T];
+function alwaysArray<T>(
+	input: T | T[],
+	options?: { convertIterables: false | undefined }
+): T[];
 function alwaysArray<T>(
 	input: Iterable<T>,
-	options?: { convertIterables: true }
+	options: { convertIterables: true }
 ): T[];
 function alwaysArray<T>(input: SingleOrArray<T>, options?: Options): T[] {
 	options = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-type SingleOrArray<T> = T | T[] | Iterable<T> | readonly T[];
+type SingleOrArray<T> = T | Iterable<T> | readonly T[];
 
 interface Options {
 	convertIterables: boolean;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+type SingleOrArray<T> = T | T[] | Iterable<T> | readonly T[];
+
 interface Options {
 	convertIterables: boolean;
 }
@@ -8,7 +10,7 @@ interface Options {
  * @param options.convertIterables [false] Iterables will be spread into an array.
  */
 export default function alwaysArray<T>(
-	input: T | T[] | Iterable<T>,
+	input: SingleOrArray<T>,
 	options?: Options
 ): T[] {
 	options = {
@@ -16,16 +18,16 @@ export default function alwaysArray<T>(
 		...options
 	};
 
-	if (
-		options.convertIterables === true &&
-		input !== null &&
-		typeof input !== 'string' &&
-		typeof (input as Iterable<T>)[Symbol.iterator] === 'function'
-	) {
-		return [...(input as Iterable<T>)];
-	}
+	const isArray = Array.isArray(input);
 
-	return Array.isArray(input) ? input : [input as T];
+	const isIterable =
+		isArray ||
+		(options.convertIterables === true &&
+			input !== null &&
+			typeof input !== 'string' &&
+			typeof (input as Iterable<T>)[Symbol.iterator] === 'function');
+
+	return isIterable ? [...(input as Iterable<T>)] : [input as T];
 }
 
 if (typeof module !== 'undefined') {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,27 @@
-export default function alwaysArray<T>(input: T | T[]): T[] {
+interface Options {
+	convertIterables: boolean;
+}
+
+/**
+ * Makes sure you're dealing with an array.
+ * @param input Input that will be converted to an array if it isn't already.
+ * @param options.convertIterables [false] Iterables will be spread into an array.
+ */
+export default function alwaysArray<T>(input: T | T[], options?: Options): T[] {
+	options = {
+		convertIterables: false,
+		...options
+	};
+
+	if (
+		options.convertIterables === true &&
+		input !== null &&
+		typeof input !== 'string' &&
+		typeof (input as Iterable<any>)[Symbol.iterator] === 'function'
+	) {
+		return [...(input as Iterable<any>)];
+	}
+
 	return Array.isArray(input) ? input : [input];
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,10 +9,14 @@ interface Options {
  * @param input Input that will be converted to an array if it isn't already.
  * @param options.convertIterables [false] Iterables will be spread into an array.
  */
-export default function alwaysArray<T>(
-	input: SingleOrArray<T>,
-	options?: Options
-): T[] {
+function alwaysArray(input: string, options?: Options): [string];
+function alwaysArray<T>(input: T[], options?: Options): T[];
+function alwaysArray<T>(input: T, options?: { convertIterables: false }): [T];
+function alwaysArray<T>(
+	input: Iterable<T>,
+	options?: { convertIterables: true }
+): T[];
+function alwaysArray<T>(input: SingleOrArray<T>, options?: Options): T[] {
 	options = {
 		convertIterables: false,
 		...options
@@ -30,7 +34,10 @@ export default function alwaysArray<T>(
 	return isIterable ? [...(input as Iterable<T>)] : [input as T];
 }
 
+export default alwaysArray;
+
 if (typeof module !== 'undefined') {
 	module.exports = alwaysArray;
 	module.exports.default = alwaysArray;
 }
+

--- a/src/tests/convertIterables.test.ts
+++ b/src/tests/convertIterables.test.ts
@@ -1,19 +1,17 @@
 import { expect } from 'chai';
-import alwaysArray from '..';
+import { convertIterables } from '..';
 import 'mocha';
 
 describe('convert iterables', () => {
 	it('should spread the iterable', () => {
-		const result = alwaysArray(new Set([1, 2, 3]), { convertIterables: true });
+		const result = convertIterables(new Set([1, 2, 3]));
 
 		expect(result).to.eql([1, 2, 3]);
 	});
 
-	it("shouldn't spread the iterable", () => {
-		const set = alwaysArray(new Set([1, 2, 3]));
-		const string = alwaysArray('foo', { convertIterables: true });
+	it("shouldn't spread strings", () => {
+		const string = convertIterables('foo');
 
-		expect(set).to.eql([new Set([1, 2, 3])]);
 		expect(string).to.eql(['foo']);
 	});
 });

--- a/src/tests/convertIterables.test.ts
+++ b/src/tests/convertIterables.test.ts
@@ -10,7 +10,10 @@ describe('convert iterables', () => {
 	});
 
 	it("shouldn't spread the iterable", () => {
-		const result = alwaysArray(new Set([1, 2, 3]));
-		expect(result).to.eql([new Set([1, 2, 3])]);
+		const set = alwaysArray(new Set([1, 2, 3]));
+		const string = alwaysArray('foo', { convertIterables: true });
+
+		expect(set).to.eql([new Set([1, 2, 3])]);
+		expect(string).to.eql(['foo']);
 	});
 });

--- a/src/tests/convertIterables.test.ts
+++ b/src/tests/convertIterables.test.ts
@@ -1,0 +1,16 @@
+import { expect } from 'chai';
+import alwaysArray from '..';
+import 'mocha';
+
+describe('convert iterables', () => {
+	it('should spread the iterable', () => {
+		const result = alwaysArray(new Set([1, 2, 3]), { convertIterables: true });
+
+		expect(result).to.eql([1, 2, 3]);
+	});
+
+	it("shouldn't spread the iterable", () => {
+		const result = alwaysArray(new Set([1, 2, 3]));
+		expect(result).to.eql([new Set([1, 2, 3])]);
+	});
+});


### PR DESCRIPTION
Adds the option for iterable to array conversion.

```ts
const set = new Set([1, 2, 3]);
alwaysArray(set); // [ Set { 1, 2, 3 } ]
alwaysArray(set, { convertIterables: true }); // [1, 2, 3]
```